### PR TITLE
Use Python 3 regardless of system defaults

### DIFF
--- a/Reader.py
+++ b/Reader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import tkinter as tk
 from PIL import Image, ImageTk
 import os


### PR DESCRIPTION
Many distributions still use Python 2 as the default.
