### PR TITLE
Fix crash when there's no last_page in the current directory

### DIFF
--- a/Reader.py
+++ b/Reader.py
@@ -50,6 +50,8 @@ class Application(tk.Frame):
 				self.current_page = 0
 			last_page.close()
 		else:
+			self.last_page_json = dict()
+			self.last_page_json[self.images.path] = 0
 			self.current_page = 0
 		self.pack(fill=tk.BOTH, expand=1)
 		self.createWidgets()


### PR DESCRIPTION
Fixes this:

``` python
Traceback (most recent call last):
  File "./Reader.py", line 347, in <module>
    main()
  File "./Reader.py", line 343, in main
    app.update_screen()
  File "./Reader.py", line 137, in update_screen
    self.change_image(0)
  File "./Reader.py", line 232, in change_image
    self.last_page_json[self.images.path] = new_page
AttributeError: 'Application' object has no attribute 'last_page_json'
```
