### PR TITLE
installation instructions for arch without using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Arch Linux without using pip
 
 install Tk, Tesseract and various python modules
 
-`sudo pacman -S tk tesseract tesseract-data-jpn python-pillow python-pyocr python-magic python-myougiden-git python-rarfile`
+`sudo pacman -S tk tesseract tesseract-data-jpn python-pillow python-magic python-rarfile`
+
+install the remaining python modules from the AUR either manually or by using an AUR helper like yaourt
+
+`yaourt -S python-pyocr python-myougiden-git python-rarfile`
 
 Arch Linux using pip
 ----------

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Arch Linux without using pip
 
 install Tk, Tesseract and various python modules
 
-`sudo pacman -S tk tesseract tesseract-data-jpn python-pillow python-magic python-rarfile`
+`sudo pacman -S tk tesseract tesseract-data-jpn python-pillow python-rarfile`
 
 install the remaining python modules from the AUR either manually or by using an AUR helper like yaourt
 
-`yaourt -S python-pyocr python-myougiden-git python-rarfile`
+`yaourt -S python-pyocr python-myougiden-git python-rarfile`python-magic-ahupp
 
 Arch Linux using pip
 ----------

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ install Tk, Tesseract and various python modules
 
 install the remaining python modules from the AUR either manually or by using an AUR helper like yaourt
 
-`yaourt -S python-pyocr python-myougiden-git python-rarfile`python-magic-ahupp
+`yaourt -S python-pyocr python-myougiden python-rarfile python-magic-ahupp`
 
 Arch Linux using pip
 ----------

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ OCR-Manga has a few dependencies you will need:
   - Most distributions have tkinter available in their package repositories
 - [Tesseract](https://github.com/tesseract-ocr/tesseract)
   - You will also need the [jpn data files](https://github.com/tesseract-ocr/langdata)
-  - Most distributions have both Tesseract and various language data available 
+  - Most distributions have both Tesseract and various language data available  
     in their package repositories.
 - [pillow](https://github.com/python-pillow/Pillow)
 - [pyocr](https://github.com/jflesch/pyocr)
@@ -24,14 +24,18 @@ Install pip, Tk, and Tesseract:
 
 `sudo apt-get install python3-pip python3-tk tesseract-ocr tesseract-ocr-jpn`
 
-
-Arch Linux
+Arch Linux without using pip
 ----------
 
+install Tk, Tesseract and various python modules
+
+`sudo pacman -S tk tesseract tesseract-data-jpn python-pillow python-pyocr python-magic python-myougiden-git python-rarfile`
+
+Arch Linux using pip
+----------
 Install pip, Tk, and Tesseract:
 
 `sudo pacman -S python-pip tk tesseract tesseract-data-jpn`
-
 
 Gentoo
 ------
@@ -42,6 +46,7 @@ either have `ja` in your L10N or specify `l10n_ja` as an USE flag for Tesseract.
 Install pip and Tesseract:
 
 `sudo emerge -a dev-python/pip app-lang/tesseract`
+
 
 Install various python modules:
 -------------------------------


### PR DESCRIPTION
It's not recommended to install python modules directly with pip on arch so I suggest including install instructions without pip but by using the oficial repos and the AUR instead. I've added the romkan and myougiden modules to the AUR since they were not available yet.